### PR TITLE
Modernise and fix API (breaking)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ MANIFEST
 cobertura.xml
 .coverage
 nosetests.xml
+.tox/
+hotqueue/package_metadata.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 language: python
-python: 2.7
+dist: xenial
+python: 3.7
 env:
   - TOX_ENV=py27-redislite
-  - TOX_ENV=py34-redislite
+  - TOX_ENV=py35-redislite
+  - TOX_ENV=py36-redislite
+  - TOX_ENV=py37-redislite
 matrix:
   fast_finish: true
   allow_failures:
     - env:
       - TOX_ENV=py27-redis
-      - TOX_ENV=py34-redis
+      - TOX_ENV=py35-redis
+      - TOX_ENV=py36-redis
+      - TOX_ENV=py37-redis
       - TOX_ENV=build_docs
+before_install:
+  - sudo aot-get update -qq
 install:
-  - sudo apt-get update -qq
-  - pip install --upgrade pip setuptools tox virtualenv coveralls
+  - pip install tox-travis
 script:
-  - tox -v -e $TOX_ENV
+  - tox
 after_success:
   coveralls
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,32 @@
 language: python
 dist: xenial
-python: 3.7
-env:
-  - TOX_ENV=py27-redislite
-  - TOX_ENV=py35-redislite
-  - TOX_ENV=py36-redislite
-  - TOX_ENV=py37-redislite
-  - TOX_ENV=py27-redis
-  - TOX_ENV=py35-redis
-  - TOX_ENV=py36-redis
-  - TOX_ENV=py37-redis
-  - TOX_ENV=build_docs
-  - TOX_ENV=pylint
-  - TOX_ENV=pep8
+
 matrix:
+  include:
+    - python: 3.7
+      env: TOX_ENV=py37-redislite
+    - python: 3.7
+      env: TOX_ENV=build_docs
+    - python: 3.7
+      env: TOX_ENV=pylint
+    - python: 3.7
+      env: TOX_ENV=pep8
+    - python: 3.6
+      env: TOX_ENV=py36-redislite
+    - python: 3.5
+      env: TOX_ENV=py35-redislite
+    - python: 2.7
+      env: TOX_ENV=py27-redislite
+    # todo: test against redis?
   fast_finish: true
   allow_failures:
     - env:
-      - TOX_ENV=py27-redis
-      - TOX_ENV=py35-redis
-      - TOX_ENV=py36-redis
-      - TOX_ENV=py37-redis
-      - TOX_ENV=build_docs
       - TOX_ENV=pylint
-      - TOX_ENV=pep8
+
 before_install:
   - sudo apt-get update -qq
-  - pip install tox-travis
-script: tox
+  - pip install tox
+script: tox -v -e $TOX_ENV
 after_success: coveralls
 after_failure:
   - for X in .tox/$TOX_ENV/log/*; do echo "$X\n"; cat "$X"; echo "\n\n"; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ matrix:
       env: TOX_ENV=py37-redislite
     - python: 3.7
       env: TOX_ENV=build_docs
-    - python: 3.7
-      env: TOX_ENV=pylint
+    # todo: use a less finnicky linter which has a chance of passing
+#    - python: 3.7
+#      env: TOX_ENV=pylint
     - python: 3.7
       env: TOX_ENV=pep8
     - python: 3.6
@@ -19,9 +20,6 @@ matrix:
       env: TOX_ENV=py27-redislite
     # todo: test against redis?
   fast_finish: true
-  allow_failures:
-    - env:
-      - TOX_ENV=pylint
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ env:
   - TOX_ENV=py35-redislite
   - TOX_ENV=py36-redislite
   - TOX_ENV=py37-redislite
+  - TOX_ENV=py27-redis
+  - TOX_ENV=py35-redis
+  - TOX_ENV=py36-redis
+  - TOX_ENV=py37-redis
+  - TOX_ENV=build_docs
+  - TOX_ENV=pylint
+  - TOX_ENV=pep8
 matrix:
   fast_finish: true
   allow_failures:
@@ -15,14 +22,13 @@ matrix:
       - TOX_ENV=py36-redis
       - TOX_ENV=py37-redis
       - TOX_ENV=build_docs
+      - TOX_ENV=pylint
+      - TOX_ENV=pep8
 before_install:
-  - sudo aot-get update -qq
-install:
+  - sudo apt-get update -qq
   - pip install tox-travis
-script:
-  - tox
-after_success:
-  coveralls
+script: tox
+after_success: coveralls
 after_failure:
   - for X in .tox/$TOX_ENV/log/*; do echo "$X\n"; cat "$X"; echo "\n\n"; done
   - echo "pip.log\n"; cat $HOME/.pip/pip.log

--- a/hotqueue/__init__.py
+++ b/hotqueue/__init__.py
@@ -48,9 +48,9 @@ Example:
 import json
 import os
 from .hotqueue import HotQueue
+from .serializers import PickleSerializer
 
-
-__all__ = ['hotqueue']
+__all__ = ['HotQueue', 'PickleSerializer']
 __version__ = str('0.0.0')
 __git_version__ = str("")
 __git_origin__ = str("")
@@ -77,3 +77,12 @@ if os.path.exists(_metadata_file):  # pragma: no cover
         if __git_origin__.endswith('.git'):  # pragma: no cover
             __git_base_url__ = __git_origin__[:-4].strip('/')
         __source_url__ = __git_base_url__ + '/tree/' + __git_hash__
+
+
+__version_info__ = tuple()
+for item in __version__:
+    try:
+        item = int(item)
+    except (ValueError, TypeError):
+        pass
+    __version_info__ += (item,)

--- a/hotqueue/compat.py
+++ b/hotqueue/compat.py
@@ -1,0 +1,19 @@
+try:
+    import queue
+except ImportError:  # pragma: no cover
+    import Queue as queue
+
+try:
+    import pickle5 as pickle
+except ImportError:  # pragma: no cover
+    try:
+        import cPickle as pickle
+    except ImportError:
+        import pickle
+
+try:
+    from redislite import Redis
+except ImportError:  # pragma: no cover
+    from redis import Redis
+
+__all__ = ["queue", "pickle", "Redis"]

--- a/hotqueue/hotqueue.py
+++ b/hotqueue/hotqueue.py
@@ -161,8 +161,7 @@ class HotQueue(object):
                 raise queue.Empty("Redis queue {} was empty after {}s".format(
                     self.key, timeout
                 ))
-            else:
-                msg = msg[1]
+            msg = msg[1]
         else:
             msg = self._redis.lpop(self.key)
             if msg is None:

--- a/hotqueue/hotqueue.py
+++ b/hotqueue/hotqueue.py
@@ -5,7 +5,12 @@ within your Python programs.
 """
 from __future__ import print_function
 from functools import wraps
-from queue import Empty
+
+try:
+    from queue import Empty
+except ImportError:  # pragma: no cover
+    from Queue import Empty
+
 try:
     import cPickle as pickle
 except ImportError:  # pragma: no cover

--- a/hotqueue/hotqueue.py
+++ b/hotqueue/hotqueue.py
@@ -6,20 +6,7 @@ within your Python programs.
 from __future__ import print_function
 from functools import wraps
 
-try:
-    from queue import Empty
-except ImportError:  # pragma: no cover
-    from Queue import Empty
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
-
-try:
-    from redislite import Redis
-except ImportError:  # pragma: no cover
-    from redis import Redis
+from .compat import queue, pickle, Redis
 
 
 def key_for_name(name):
@@ -130,7 +117,7 @@ class HotQueue(object):
         while count < limit:
             try:
                 msg = self.get(**kwargs)
-            except Empty:
+            except queue.Empty:
                 break
             yield msg
             count += 1
@@ -169,7 +156,7 @@ class HotQueue(object):
                 timeout = 0
             msg = self._redis.blpop(self.key, timeout=timeout)
             if msg is None:
-                raise Empty("Redis queue {} was empty after {}s".format(
+                raise queue.Empty("Redis queue {} was empty after {}s".format(
                     self.key, timeout
                 ))
             else:
@@ -177,7 +164,7 @@ class HotQueue(object):
         else:
             msg = self._redis.lpop(self.key)
             if msg is None:
-                raise Empty("Redis queue {} is empty".format(self.key))
+                raise queue.Empty("Redis queue {} is empty".format(self.key))
 
         if msg is not None and self.serializer is not None:
             msg = self.serializer.loads(msg)

--- a/hotqueue/hotqueue.py
+++ b/hotqueue/hotqueue.py
@@ -71,12 +71,12 @@ class HotQueue(object):
         self.serializer = serializer
         self.max_queue_length = max_queue_length
         if redis:
-            self.__redis = redis
+            self._redis = redis
         else:
-            self.__redis = Redis(**kwargs)
+            self._redis = Redis(**kwargs)
 
     def __len__(self):
-        return self.__redis.llen(self.key)
+        return self._redis.llen(self.key)
 
     @property
     def key(self):
@@ -94,7 +94,7 @@ class HotQueue(object):
         """
         Clear the queue of all messages, by deleting the Redis key.
         """
-        self.__redis.delete(self.key)
+        self._redis.delete(self.key)
 
     def consume(self, limit=None, **kwargs):
         """
@@ -167,7 +167,7 @@ class HotQueue(object):
         if block:
             if timeout is None:
                 timeout = 0
-            msg = self.__redis.blpop(self.key, timeout=timeout)
+            msg = self._redis.blpop(self.key, timeout=timeout)
             if msg is None:
                 raise Empty("Redis queue {} was empty after {}s".format(
                     self.key, timeout
@@ -175,7 +175,7 @@ class HotQueue(object):
             else:
                 msg = msg[1]
         else:
-            msg = self.__redis.lpop(self.key)
+            msg = self._redis.lpop(self.key)
             if msg is None:
                 raise Empty("Redis queue {} is empty".format(self.key))
 
@@ -200,9 +200,9 @@ class HotQueue(object):
         """
         if self.serializer is not None:
             msgs = [self.serializer.dumps(m) for m in msgs]
-        self.__redis.rpush(self.key, *msgs)
+        self._redis.rpush(self.key, *msgs)
         if self.max_queue_length:
-            self.__redis.ltrim(self.key, 0, int(self.max_queue_length) - 1)
+            self._redis.ltrim(self.key, 0, int(self.max_queue_length) - 1)
 
     def worker(self, *args, **kwargs):
         """Decorator for using a function as a queue worker. Example:

--- a/hotqueue/hotqueue.py
+++ b/hotqueue/hotqueue.py
@@ -33,8 +33,9 @@ class HotQueue(object):
         `pickle <http://docs.python.org/library/pickle.html>`_ is the default,
         use ``None`` to store messages in plain text (suitable for strings,
         integers, etc).
-        Consider using a hotqueue.PickleSerializer, which uses the newest pickle
-        protocol available, rather than a lower version for compatibility.
+        Consider using a hotqueue.PickleSerializer, which uses the newest
+        pickle protocol available, rather than a lower version for
+        compatibility.
 
     redis : redis.Redis, redislite.Redis, optional
         redis connection object, defaults to redislite.Redis with fallback to

--- a/hotqueue/hotqueue.py
+++ b/hotqueue/hotqueue.py
@@ -32,7 +32,9 @@ class HotQueue(object):
         methods or functions named ``dumps`` and ``loads``,
         `pickle <http://docs.python.org/library/pickle.html>`_ is the default,
         use ``None`` to store messages in plain text (suitable for strings,
-        integers, etc)
+        integers, etc).
+        Consider using a hotqueue.PickleSerializer, which uses the newest pickle
+        protocol available, rather than a lower version for compatibility.
 
     redis : redis.Redis, redislite.Redis, optional
         redis connection object, defaults to redislite.Redis with fallback to

--- a/hotqueue/serializers.py
+++ b/hotqueue/serializers.py
@@ -1,0 +1,26 @@
+from copy import deepcopy
+
+from .compat import pickle
+
+
+def merge_kwargs(*dicts, **kwargs):
+    out = dict()
+    for d in dicts:
+        out.update(d)
+    out.update(kwargs)
+    return out
+
+
+class PickleSerializer(object):
+    def __init__(self, protocol=pickle.HIGHEST_PROTOCOL, dumps_kwargs=None, loads_kwargs=None):
+        self.protocol = protocol
+        self.dumps_kwargs = deepcopy(dumps_kwargs) or dict()
+        self.dumps_kwargs["protocol"] = self.dumps_kwargs.get("protocol", protocol)
+        self.loads_kwargs = deepcopy(loads_kwargs) or dict()
+        self.loads_kwargs["protocol"] = self.loads_kwargs.get("protocol", protocol)
+
+    def dumps(self, obj, **kwargs):
+        return pickle.dumps(obj, **merge_kwargs(self.dumps_kwargs, kwargs))
+
+    def loads(self, s, **kwargs):
+        return pickle.loads(s, **merge_kwargs(self.dumps_kwargs, kwargs))

--- a/hotqueue/serializers.py
+++ b/hotqueue/serializers.py
@@ -24,12 +24,9 @@ class PickleSerializer(object):
             "protocol", protocol
         )
         self.loads_kwargs = deepcopy(loads_kwargs) or dict()
-        self.loads_kwargs["protocol"] = self.loads_kwargs.get(
-            "protocol", protocol
-        )
 
     def dumps(self, obj, **kwargs):
         return pickle.dumps(obj, **merge_kwargs(self.dumps_kwargs, kwargs))
 
     def loads(self, s, **kwargs):
-        return pickle.loads(s, **merge_kwargs(self.dumps_kwargs, kwargs))
+        return pickle.loads(s, **merge_kwargs(self.loads_kwargs, kwargs))

--- a/hotqueue/serializers.py
+++ b/hotqueue/serializers.py
@@ -12,12 +12,21 @@ def merge_kwargs(*dicts, **kwargs):
 
 
 class PickleSerializer(object):
-    def __init__(self, protocol=pickle.HIGHEST_PROTOCOL, dumps_kwargs=None, loads_kwargs=None):
+    def __init__(
+        self,
+        protocol=pickle.HIGHEST_PROTOCOL,
+        dumps_kwargs=None,
+        loads_kwargs=None
+    ):
         self.protocol = protocol
         self.dumps_kwargs = deepcopy(dumps_kwargs) or dict()
-        self.dumps_kwargs["protocol"] = self.dumps_kwargs.get("protocol", protocol)
+        self.dumps_kwargs["protocol"] = self.dumps_kwargs.get(
+            "protocol", protocol
+        )
         self.loads_kwargs = deepcopy(loads_kwargs) or dict()
-        self.loads_kwargs["protocol"] = self.loads_kwargs.get("protocol", protocol)
+        self.loads_kwargs["protocol"] = self.loads_kwargs.get(
+            "protocol", protocol
+        )
 
     def dumps(self, obj, **kwargs):
         return pickle.dumps(obj, **merge_kwargs(self.dumps_kwargs, kwargs))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+setuptools
+tox
+redislite
+redis
+nose
+nose-cov
+flake8
+sphinx
+sphinx-pypi-upload
+sphinx_rtd_theme
+pylint
+pycodestyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sphinx-pypi-upload
 sphinx_rtd_theme
 pylint
 pycodestyle
+pickle5; python_version >= 3.6 and python_version < 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ sphinx-pypi-upload
 sphinx_rtd_theme
 pylint
 pycodestyle
-pickle5; python_version >= 3.6 and python_version < 3.8
+pickle5; python_version >= "3.6" and python_version < "3.8"

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ Python program (``python tests.py``). Redis must be running on localhost:6379,
 and a list key named 'hotqueue:testqueue' will be created and deleted in db 0
 several times while the tests are running.
 """
+from queue import Empty
 from time import sleep
 import threading
 import unittest
@@ -81,7 +82,8 @@ class HotQueueTestCase(unittest.TestCase):
     def test_cleared(self):
         """Test for correct behaviour if the Redis list does not exist."""
         self.assertEqual(len(self.queue), 0)
-        self.assertEqual(self.queue.get(), None)
+        with self.assertRaises(Empty):
+            self.queue.get()
 
     def test_get_order(self):
         """Test that messages are get in the same order they are put."""

--- a/tests.py
+++ b/tests.py
@@ -11,7 +11,7 @@ import unittest
 
 from redis import DataError
 
-from hotqueue import HotQueue
+from hotqueue import HotQueue, PickleSerializer
 from hotqueue.compat import pickle, queue
 
 
@@ -58,7 +58,7 @@ class HotQueueTestCase(unittest.TestCase):
         self.assertEqual(self.queue.name, kwargs['name'])
         self.assertEqual(self.queue.key, "hotqueue:%s" % kwargs['name'])
 
-        # Defaults to cPickle or pickle depending on the platform
+        # Defaults to cPickle or pickle or pickle5 depending on the platform
         self.assertTrue(self.queue.serializer is pickle)
 
     def test_consume(self):
@@ -171,6 +171,16 @@ class HotQueueTestCase(unittest.TestCase):
         self.queue.serializer = DummySerializer
         self.queue.put(msg)
         self.assertEqual(self.queue.get(), "foo")
+
+    def test_pickle_serializer(self):
+        msg = {"a": 1}
+        self.queue.serializer = PickleSerializer()
+        self.assertEqual(
+            self.queue.serializer.protocol,
+            pickle.HIGHEST_PROTOCOL
+        )
+        self.queue.put(msg)
+        self.assertEqual(self.queue.get(), msg)
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -11,17 +11,8 @@ import unittest
 
 from redis import DataError
 
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
 from hotqueue import HotQueue
+from hotqueue.compat import pickle, queue
 
 
 class DummySerializer(object):
@@ -89,7 +80,7 @@ class HotQueueTestCase(unittest.TestCase):
     def test_cleared(self):
         """Test for correct behaviour if the Redis list does not exist."""
         self.assertEqual(len(self.queue), 0)
-        with self.assertRaises(Empty):
+        with self.assertRaises(queue.Empty):
             self.queue.get()
 
     def test_get_order(self):

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,9 @@ from queue import Empty
 from time import sleep
 import threading
 import unittest
+
+from redis import DataError
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -166,8 +169,9 @@ class HotQueueTestCase(unittest.TestCase):
         self.queue.serializer = None
         self.queue.put(msg)
         self.assertEqual(self.queue.get(), msg)
-        self.queue.put({"a": 1})
-        self.assertEqual(self.queue.get(), "{'a': 1}")  # Should be a string
+        with self.assertRaises(DataError):
+            self.queue.put({"a": 1})
+
         # Test using DummySerializer:
         self.queue.serializer = DummySerializer
         self.queue.put(msg)

--- a/tests.py
+++ b/tests.py
@@ -5,12 +5,16 @@ Python program (``python tests.py``). Redis must be running on localhost:6379,
 and a list key named 'hotqueue:testqueue' will be created and deleted in db 0
 several times while the tests are running.
 """
-from queue import Empty
 from time import sleep
 import threading
 import unittest
 
 from redis import DataError
+
+try:
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
 
 try:
     import cPickle as pickle

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters=True
 # envlist = {py27,py34}-{redis,redislite}
-envlist = pylint,pep8,{py27,py34,py35,py36,py37}-{redislite}
+envlist = pylint,pep8,{py27,py35,py36,py37}-{redislite}
 
 [testenv]
 deps=
@@ -46,6 +46,6 @@ commands=
 
 [testenv:pep8]
 deps=
-    pep8
+    pycodestyle
 commands =
-    pep8 {posargs}
+    pycodestyle {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters=True
 # envlist = {py27,py34}-{redis,redislite}
-envlist = pylint,pep8,{py27,py34}-{redislite}
+envlist = pylint,pep8,{py27,py34,py35,py36,py37}-{redislite}
 
 [testenv]
 deps=


### PR DESCRIPTION
The original hotqueue suffered from a difference in API to the builtin `Queue` in that popping something from an empty queue would `return None`, like redis, rather than `raise queue.Empty`. The whole point of hotqueue is to allow people used to Queues to use redis without having to think about that underlying database, so IMO the queue-like behaviour is preferable. Also, adding None to a queue to act as a terminator for a separate process is a useful pattern; if there's no way to tell the difference between an empty and a None-containing queue, you can't do it.

Additionally:

- Allow the use of newer (and much faster) pickle protocols where supported
- requirements file for setting up a deve environment
- gitignore output files
- rename `__redis` to `_redis` because otherwise it messes up subclassing

Some of these changes were PR'd against the upstream package but that seems to be long dead.